### PR TITLE
Build process now uses Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+#
+# first_nes
+# Makefile
+#
+# Makefile ("make") configuration for iNES ROM files.
+#
+# Written by Greg M. Krsak <greg.krsak@gmail.com>, 2018
+#
+# Based on the NintendoAge "Nerdy Nights" tutorials, by bunnyboy:
+#   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
+# Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
+#   http://fms.komkon.org/EMUL8/NES.html
+# Based on "Nintendo Entertainment System Documentation", by an unknown author:
+#   https://emu-docs.org/NES/nestech.txt
+#
+# Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)
+# Assembler: ca65 (cc65 binutils)
+#
+# Tested with:
+#  make
+#  nestopia first_nes.nes
+#
+# Tested on:
+#  - Linux
+#  - Nestopia UE 1.47
+#
+# For more information about NES programming in general, try these references:
+# https://en.wikibooks.org/wiki/NES_Programming
+#
+# For more information on the ca65 assembler, try these references:
+# https://github.com/cc65/cc65
+# http://cc65.github.io/doc/ca65.html
+#
+
+
+# Reference: https://www.cs.swarthmore.edu/~newhall/unixhelp/howto_makefiles.html
+
+
+# Makefile variable for the assembler 
+ASSEMBLER = ca65
+
+# Makefile variable for the linker 
+LINKER = ld65
+
+# Makefile variable for assembly flags
+ASMFLAGS = --cpu 6502
+
+# Makefile variable for linker flags
+LINKFLAGS = --config config/ines.cfg
+
+# Simply typing "make" will invoke all targets required to build an emulator-ready ROM
+default: clean assemble link emulator emulator-post-clean
+
+# To start over from scratch, type "make clean"
+clean: universal-pre-clean emulator-post-clean
+	
+# This target entry assembles the .s assembly language files into .o object files
+assemble: first_nes.s
+	$(ASSEMBLER) $(ASMFLAGS) first_nes.s
+
+# This target entry links the .o object files into .bin ROM files
+link: first_nes.o
+	$(LINKER) first_nes.o $(LINKFLAGS)
+
+# This target entry concatenates the .bin ROM files into a .nes iNES emulator-compatible ROM file
+emulator: bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin
+	cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
+
+# This target entry removes any build files (.bin, .nes) associated with an NES ROM 
+universal-pre-clean:
+	$(RM) bin/*.bin && $(RM) first_nes.nes
+
+# This target entry removes the files (.o, .out) not required by emulators
+emulator-post-clean:
+	$(RM) first_nes.o && $(RM) a.out
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ first_nes project (WIP)
 
 
 A "starter" assembly language game for the Nintendo Entertainment System.
-Please leave issues or submit pull requests!
+Please feel free to leave issues or submit pull requests.
 -------------------------------------------------------------------------
 
 
@@ -22,18 +22,15 @@ Based on ["Nintendo Entertainment System Documentation"](https://emu-docs.org/NE
 **Tested with:**
 
 ```bash
-rm bin/*.bin
-rm first_nes.nes
-ca65 first_nes.s
-ld65 first_nes.o -C config/ines.cfg
-cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-rm a.out && rm first_nes.o
+make
 nestopia first_nes.nes
 ```
 
 **Tested on:**
 
-[Nestopia UE](http://0ldsk00l.ca/nestopia/) 1.47
+- Linux
+
+- [Nestopia UE](http://0ldsk00l.ca/nestopia/) 1.47
 
 
 For more information about NES programming in general, try these references:

--- a/common/apu.inc
+++ b/common/apu.inc
@@ -17,14 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C ld65.cfg
-;  cat first_nes_hdr.bin first_nes_prg.bin first_nes_chr.bin > first_nes.nes
-;  rm a.out
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/common/controllers.inc
+++ b/common/controllers.inc
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/common/cpu.inc
+++ b/common/cpu.inc
@@ -17,14 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C ld65.cfg
-;  cat first_nes_hdr.bin first_nes_prg.bin first_nes_chr.bin > first_nes.nes
-;  rm a.out
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/common/ppu.inc
+++ b/common/ppu.inc
@@ -17,14 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C ld65.cfg
-;  cat first_nes_hdr.bin first_nes_prg.bin first_nes_chr.bin > first_nes.nes
-;  rm a.out
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/config/ines.cfg
+++ b/config/ines.cfg
@@ -18,16 +18,12 @@
 # Assembler: ca65 (cc65 binutils)
 #
 # Tested with:
-#  rm bin/*.bin
-#  rm first_nes.nes
-#  ca65 first_nes.s
-#  ld65 first_nes.o -C config/ines.cfg
-#  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-#  rm a.out && rm first_nes.o
+#  make
 #  nestopia first_nes.nes
 #
 # Tested on:
-#  Nestopia UE 1.47
+#  - Linux
+#  - Nestopia UE 1.47
 #
 # For more information about NES programming in general, try these references:
 # https://en.wikibooks.org/wiki/NES_Programming

--- a/data/header/ines_simple.inc
+++ b/data/header/ines_simple.inc
@@ -20,16 +20,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/data/palette/example.inc
+++ b/data/palette/example.inc
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/data/sprites/small_luigi.inc
+++ b/data/sprites/small_luigi.inc
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/first_nes.s
+++ b/first_nes.s
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/lib/isr/custom.s
+++ b/lib/isr/custom.s
@@ -19,16 +19,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/lib/isr/poweron_reset.s
+++ b/lib/isr/poweron_reset.s
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/lib/isr/vertical_blank.s
+++ b/lib/isr/vertical_blank.s
@@ -19,16 +19,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/lib/sprite/basic_movement.s
+++ b/lib/sprite/basic_movement.s
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/apu.inc
+++ b/shared_code/apu.inc
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/apu.s
+++ b/shared_code/apu.s
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/controllers.inc
+++ b/shared_code/controllers.inc
@@ -17,14 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/cpu.inc
+++ b/shared_code/cpu.inc
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/cpu.s
+++ b/shared_code/cpu.s
@@ -17,17 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
-
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/ppu.inc
+++ b/shared_code/ppu.inc
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming

--- a/shared_code/ppu.s
+++ b/shared_code/ppu.s
@@ -17,16 +17,12 @@
 ; Assembler: ca65 (cc65 binutils)
 ;
 ; Tested with:
-;  rm bin/*.bin
-;  rm first_nes.nes
-;  ca65 first_nes.s
-;  ld65 first_nes.o -C config/ines.cfg
-;  cat bin/first_nes_hdr.bin bin/first_nes_prg.bin bin/first_nes_chr.bin > first_nes.nes
-;  rm a.out && rm first_nes.o
+;  make
 ;  nestopia first_nes.nes
 ;
 ; Tested on:
-;  Nestopia UE 1.47
+;  - Linux
+;  - Nestopia UE 1.47
 ;
 ; For more information about NES programming in general, try these references:
 ; https://en.wikibooks.org/wiki/NES_Programming


### PR DESCRIPTION
You may now use "make" to build the first_nes project.

See Makefile for a list of possible targets.
