### PR TITLE
Globally-applied changes from ddc0252

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 # Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 #   http://fms.komkon.org/EMUL8/NES.html
-# Based on "Nintendo Entertainment System Documentation", by an unknown author:
+# Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 #   https://emu-docs.org/NES/nestech.txt
 #
 # Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Credits
 
 - [@elennick](https://github.com/elennick) for testing the Mac OS quick start instructions (Issue [#22](https://github.com/gregkrsak/first_nes/issues/22)).
 
+- [@hxlnt](https://github.com/hxlnt) for expanding the credits (PR [#33](https://github.com/gregkrsak/first_nes/pull/33)).
+
 
 About my Development Environment
 --------------------------------

--- a/common/apu.inc
+++ b/common/apu.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/common/controllers.inc
+++ b/common/controllers.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/common/cpu.inc
+++ b/common/cpu.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/common/ppu.inc
+++ b/common/ppu.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/config/ines.cfg
+++ b/config/ines.cfg
@@ -11,7 +11,7 @@
 #   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 # Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 #   http://fms.komkon.org/EMUL8/NES.html
-# Based on "Nintendo Entertainment System Documentation", by an unknown author:
+# Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 #   https://emu-docs.org/NES/nestech.txt
 #
 # Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/data/header/ines_simple.inc
+++ b/data/header/ines_simple.inc
@@ -13,7 +13,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/data/palette/example.inc
+++ b/data/palette/example.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/data/sprites/small_luigi.inc
+++ b/data/sprites/small_luigi.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/first_nes.s
+++ b/first_nes.s
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/isr/custom.s
+++ b/lib/isr/custom.s
@@ -12,7 +12,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/isr/poweron_reset.s
+++ b/lib/isr/poweron_reset.s
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/isr/vertical_blank.s
+++ b/lib/isr/vertical_blank.s
@@ -12,7 +12,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/apu.inc
+++ b/lib/shared_code/apu.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/apu.s
+++ b/lib/shared_code/apu.s
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/controllers.inc
+++ b/lib/shared_code/controllers.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/cpu.inc
+++ b/lib/shared_code/cpu.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/cpu.s
+++ b/lib/shared_code/cpu.s
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/ppu.inc
+++ b/lib/shared_code/ppu.inc
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/shared_code/ppu.s
+++ b/lib/shared_code/ppu.s
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)

--- a/lib/sprite/basic_movement.s
+++ b/lib/sprite/basic_movement.s
@@ -10,7 +10,7 @@
 ;   http://nintendoage.com/forum/messageview.cfm?catid=22&threadid=7155
 ; Based on "Nintendo Entertainment System Architecture", by Marat Fayzullin:
 ;   http://fms.komkon.org/EMUL8/NES.html
-; Based on "Nintendo Entertainment System Documentation", by an unknown author:
+; Based on "Nintendo Entertainment System Documentation", by Jeremy Chadwick:
 ;   https://emu-docs.org/NES/nestech.txt
 ;
 ; Processor: 8-bit, Ricoh RP2A03 (6502), 1.789773 MHz (NTSC)


### PR DESCRIPTION
1. 8a17fd7 - Jeremy Chadwick (formerly "an unknown author") was credited as the author of "Nintendo Entertainment System Documentation" at https://emu-docs.org/NES/nestech.txt

2. d621cca - Rachel Simone Weil as (@hxlnt) was credited for pointing out that Jeremy Chadwick was the unknown author.