### PR TITLE
Closes #45 - Improve readme header/catchphrase

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ first_nes project (WIP)
 [![GitHub last commit](https://img.shields.io/github/last-commit/gregkrsak/first_nes.svg)](https://github.com/gregkrsak/first_nes/commits/)
 
 
-**A "starter" assembly language game for the Nintendo Entertainment System.**
+**Create your own games for the Nintendo Entertainment System with this "starter" project!**
 
 
 **If you'd like to contribute, [click here](https://github.com/gregkrsak/first_nes/blob/master/docs/CONTRIBUTING.md) so we can synchronize our expectations!**

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,9 @@ first_nes project (WIP)
 
 **If you'd like to contribute, [click here](https://github.com/gregkrsak/first_nes/blob/master/docs/CONTRIBUTING.md) so we can synchronize our expectations!**
 
+![Image: Editing](https://i.imgur.com/EabWh01.png "Boilerplate code is provided! Just add custom libraries, and graphics if you'd like.")
+![Image: Running](https://i.imgur.com/GcwC0tR.png "Instantly get up and running!")
+
 
 Quick Start
 -----------

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,12 @@ first_nes project (WIP)
 
 **Create your own games for the Nintendo Entertainment System with this "starter" project!**
 
-
 **If you'd like to contribute, [click here](https://github.com/gregkrsak/first_nes/blob/master/docs/CONTRIBUTING.md) so we can synchronize our expectations!**
 
-![Image: Editing](https://i.imgur.com/EabWh01.png "Boilerplate code is provided! Just add custom libraries, and graphics if you'd like.") ![Image: Running](https://i.imgur.com/GcwC0tR.png "Instantly get up and running!")
+
+Boilerplate code is provided!       |  Instantly get up and playing!
+------------------------------------|-----------------------------------
+![Image: Editing](https://i.imgur.com/EabWh01.png "Boilerplate code is provided! Just add custom libraries, and graphics if you'd like.")  |  ![Image: Running](https://i.imgur.com/GcwC0tR.png "Instantly get up and playing!")
 
 
 Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,7 @@ first_nes project (WIP)
 
 **If you'd like to contribute, [click here](https://github.com/gregkrsak/first_nes/blob/master/docs/CONTRIBUTING.md) so we can synchronize our expectations!**
 
-![Image: Editing](https://i.imgur.com/EabWh01.png "Boilerplate code is provided! Just add custom libraries, and graphics if you'd like.")
-![Image: Running](https://i.imgur.com/GcwC0tR.png "Instantly get up and running!")
+![Image: Editing](https://i.imgur.com/EabWh01.png "Boilerplate code is provided! Just add custom libraries, and graphics if you'd like.") ![Image: Running](https://i.imgur.com/GcwC0tR.png "Instantly get up and running!")
 
 
 Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ first_nes project (WIP)
 [![GitHub last commit](https://img.shields.io/github/last-commit/gregkrsak/first_nes.svg)](https://github.com/gregkrsak/first_nes/commits/)
 
 
-**Create your own games for the Nintendo Entertainment System with this "starter" project!**
+Create your own games for the Nintendo Entertainment System with this "starter" project!
 
-**If you'd like to contribute, [click here](https://github.com/gregkrsak/first_nes/blob/master/docs/CONTRIBUTING.md) so we can synchronize our expectations!**
+If you'd like to contribute, [click here](https://github.com/gregkrsak/first_nes/blob/master/docs/CONTRIBUTING.md) so we can synchronize our expectations!
 
 
 Boilerplate code is provided!       |  Instantly get up and playing!


### PR DESCRIPTION
1. 6f629b5 - Added screenshots linked to imgur.com
2. df8e59f - Improved the general catchphrase below the project title and badges
3. 4c195ff - Failed attempt to make images reliably side-by-side instead of vertical
4. 3233bd9 - Proper image alignment thanks to https://stackoverflow.com/questions/24319505/how-can-one-display-images-side-by-side-in-a-github-readme-md
5. d94acb1 - Removed bold text from general catchphrase