### PR TITLE
Enabled background tile rendering. 

### DIFF
--- a/data/background/scene.inc
+++ b/data/background/scene.inc
@@ -1,0 +1,20 @@
+;
+; first_nes (https://github.com/gregkrsak/first_nes/)
+; data/background/scene.inc
+;
+; Sample nametable to produce a background scene.
+; Uses data/tiles/smb1_chr.bin
+;
+; Please see first_nes/docs/README.md for license and attribution.
+
+
+_NAMETABLE:
+  .BYTE $24,$24,$24,$24,$24,$24,$24,$24,$24,$24,$24,$24,$24,$24,$24,$24
+  .BYTE $24,$24,$24,$24,$24,$24,$24,$0f,$12,$1b,$1c,$1d,$24,$17,$0e,$1c ;first nes
+
+_ATTRIBUTE:
+  .BYTE %00000000,%00000000,%00000000,%00000000,%00000000,%00000000,%00000000,%00000000
+  .BYTE %00000000,%00000000,%00000000,%00000000,%00000000,%00000000,%00000000,%00000000
+
+
+; End of data/background/scene.inc

--- a/data/palette/example.inc
+++ b/data/palette/example.inc
@@ -36,8 +36,8 @@
 _PALETTE:
 
 ; Background palettes
-.BYTE $0f, $31, $32, $33
-.BYTE $0f, $35, $36, $37
+.BYTE $0f, $13, $23, $33
+.BYTE $0f, $06, $15, $36
 .BYTE $0f, $39, $3a, $3b
 .BYTE $0f, $3d, $3e, $0f
 

--- a/first_nes.s
+++ b/first_nes.s
@@ -73,6 +73,9 @@
 .SEGMENT "SPRITES"
 .INCLUDE "data/sprites/small_luigi.inc"
 
+; Background nametable and attribute data
+.INCLUDE "data/background/scene.inc"
+
 
 ; =================================================================================================
 ;  VROM (CHR) Data

--- a/lib/isr/poweron_reset.s
+++ b/lib/isr/poweron_reset.s
@@ -71,6 +71,8 @@
 
     jsr     LoadPaletteData
     jsr     LoadSpriteData                                
+    jsr     LoadBackgroundNametable
+    jsr     LoadBackgroundAttribute
     jsr     EnableVideoOutput
 
   ; -------------


### PR DESCRIPTION
Example nametable, attribute, and 'first nes' text to screen. Added code to copy nametable and attributes. Code first clears nametable ram then copies bytes over.
